### PR TITLE
Fix wrap attribute

### DIFF
--- a/src/brr.ml
+++ b/src/brr.ml
@@ -1174,7 +1174,7 @@ module At = struct
   let type' s = v Name.type' s
   let value s = v Name.value s
   let width i = int Name.width i
-  let wrap s = v Name.value s
+  let wrap s = v Name.wrap s
 end
 
 module El = struct


### PR DESCRIPTION
I was wondering why my text area was not wrapping, and discovered that the wrap attribute was defined to use `At.Name.value`, possibly due to a copy-paste error. This updates it to use `At.Name.wrap`, as I assume was
the original intention.